### PR TITLE
Allow quote-wrapped strings

### DIFF
--- a/templater/syntax.php
+++ b/templater/syntax.php
@@ -299,7 +299,7 @@ class syntax_plugin_templater extends DokuWiki_Syntax_Plugin {
 			foreach($replacers as $rep) {
 				list($k, $v) = explode('=', $rep, 2);
 				$r['keys'][] = BEGIN_REPLACE_DELIMITER.trim($k).END_REPLACE_DELIMITER;
-				$r['vals'][] = trim(str_replace('\|', '|', $v));
+				$r['vals'][] = trim(trim(str_replace('\|','|',$v)), "\"");
 			}
 		} else {
 			// This is an assertion failure. We should NEVER get here.


### PR DESCRIPTION
by trimming off quotation marks after the whitespace trim, we allow users to wrap their strings in quotation marks in order to keep any intentional leading or trailing whitespace - useful for bulleted lists, code blocks, etc..

This is the same solution I used in my (deprecated, now that you've adopted it) [personal fork](https://github.com/TurqW/templater2/blob/main/syntax.php).