### PR TITLE
remove closing PHP tags

### DIFF
--- a/debug.php
+++ b/debug.php
@@ -22,4 +22,3 @@ function printr($var, $name=null) {
     }
     echo '</pre><br />';
 }
-?>

--- a/syntax.php
+++ b/syntax.php
@@ -331,5 +331,4 @@ class syntax_plugin_templater extends DokuWiki_Syntax_Plugin {
         return $r;
     }
 }
-?>
 


### PR DESCRIPTION
Fixes premature output as reported in https://forum.dokuwiki.org/d/22063-header-errors-after-upgrade-to-kaos

See also https://www.dokuwiki.org/devel:coding_style#php_closing_tags